### PR TITLE
BlockedLores color code bug fix

### DIFF
--- a/src/main/java/com/sainttx/auctions/command/subcommand/StartCommand.java
+++ b/src/main/java/com/sainttx/auctions/command/subcommand/StartCommand.java
@@ -34,6 +34,7 @@ import com.sainttx.auctions.structure.module.AntiSnipeModule;
 import com.sainttx.auctions.structure.module.AutoWinModule;
 import com.sainttx.auctions.util.AuctionUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
@@ -255,7 +256,7 @@ public class StartCommand extends AuctionSubCommand {
 
                 for (String loreItem : lore) {
                     for (String banned : bannedLore) {
-                        if (loreItem.contains(banned)) {
+                        if (loreItem.contains(ChatColor.translateAlternateColorCodes('&', banned))) {
                             return true;
                         }
                     }


### PR DESCRIPTION
Fixes the bug where one could not block color coded strings in lores without using '§' instead of the classic '&'. One can now use both '&' and '§' to color code.